### PR TITLE
Bugfix/handle hidapi exceptions in sendReport

### DIFF
--- a/pydualsense/pydualsense.py
+++ b/pydualsense/pydualsense.py
@@ -114,6 +114,7 @@ class pydualsense:
         self.battery = DSBattery()
         self.conType = self.determineConnectionType()  # determine USB or BT connection
         self.ds_thread = True
+        self.connected = True
         self.report_thread = threading.Thread(target=self.sendReport)
         self.report_thread.start()
         self.states = None
@@ -227,18 +228,22 @@ class pydualsense:
     def sendReport(self) -> None:
         """background thread handling the reading of the device and updating its states"""
         while self.ds_thread:
-            # read data from the input report of the controller
-            inReport = self.device.read(self.input_report_length)
-            if self.verbose:
-                logger.debug(inReport)
-            # decrypt the packet and bind the inputs
-            self.readInput(inReport)
+            try:
+                # read data from the input report of the controller
+                inReport = self.device.read(self.input_report_length)
+                if self.verbose:
+                    logger.debug(inReport)
+                # decrypt the packet and bind the inputs
+                self.readInput(inReport)
 
-            # prepare new report for device
-            outReport = self.prepareReport()
+                # prepare new report for device
+                outReport = self.prepareReport()
 
-            # write the report to the device
-            self.writeReport(outReport)
+                # write the report to the device
+                self.writeReport(outReport)
+            except IOError:
+                self.connected = False
+                break
 
     def readInput(self, inReport) -> None:
         """

--- a/pydualsense/pydualsense.py
+++ b/pydualsense/pydualsense.py
@@ -244,6 +244,10 @@ class pydualsense:
             except IOError:
                 self.connected = False
                 break
+                
+            except AttributeError:
+                self.connected = False
+                break
 
     def readInput(self, inReport) -> None:
         """


### PR DESCRIPTION
Handle an exception generated by hidapi in the `sendReport` thread. This exception is thrown when no controller is connected. Since the exception is not handled, the thread ends, and the service needs to be restarted to recover. By handling these exceptions, the service becomes fault tolerant and is able to recover automatically.  

- Added a Try/Exception to handle an IOError and an AttributeError.
- Added a `Connected` property to indicate when the device is not connected.