### PR TITLE
resolve dpad down left issue

### DIFF
--- a/pydualsense/pydualsense.py
+++ b/pydualsense/pydualsense.py
@@ -684,7 +684,7 @@ class DSState:
         elif dpad_state == 5:
             self.DpadUp = False
             self.DpadDown = True
-            self.DpadLeft = False
+            self.DpadLeft = True
             self.DpadRight = False
         elif dpad_state == 6:
             self.DpadUp = False


### PR DESCRIPTION
Resolve an issue with the mapping of the `dpad_state` where the `DpadLeft` property is incorrectly set.  

- Changed the `self.DpadLeft` property assignment from `False` to `True` when `dpad_state` evaluates as `5`.